### PR TITLE
Add Reveal.js slide deck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# AI Reveal Slides
+
+This project hosts slides built with [Reveal.js](https://revealjs.com/) using Markdown as the source.
+
+## Development
+
+```bash
+npm start
+```
+
+Then open <http://localhost:8000> in a browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>The Future Is Not a Smarter Spreadsheet</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/theme/black.css" />
+  </head>
+  <body>
+    <div class="reveal">
+      <div class="slides">
+        <section data-markdown="slides.md" data-separator="^##" data-separator-vertical="^###"></section>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5/plugin/markdown/markdown.js"></script>
+    <script>
+      Reveal.initialize({
+        hash: true,
+        plugins: [ RevealMarkdown ]
+      });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-reveal-2025-09",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "python3 -m http.server",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/slides.md
+++ b/slides.md
@@ -1,44 +1,51 @@
-# The Future Is Not a Smarter Spreadsheet
+# The Future Is <span style="color:#f39c12">NOT</span> a Smarter Spreadsheet
 
 ## ⚡️ We Are Moving Fast
-- We’re entering a new era of AI-native products.
-- This isn’t "better dashboards" — it’s a different paradigm.
-- Think: real-time, multimodal, personalized, conversational interfaces.
+- We’re entering a new era of AI-native products. 
+- This isn’t “better dashboards” — it’s a different paradigm. 
+- Think: real-time, multimodal, personalized, conversational interfaces. 
 
 ## 🧠 LLMs Enable a New Kind of Interaction
-- Beyond static tools — users can *ask* instead of *search*.
-- Answers are contextual, personal, and instant.
-- People can explore without needing to know the right question or jargon.
+- Beyond static tools — users can *ask* instead of *search*. 
+- Answers are contextual, personal, and instant. 
+- People can explore without needing to know the right question or jargon. 
 
 ## 🧩 It’s a Stream, Not a Page
-- Continuous conversation across voice, text, images.
-- From PDFs to WebSocket streams — content isn’t fixed, it’s alive.
-- Memory, history, and context travel with the user.
+- Continuous conversation across voice, text, images. 
+- From PDFs to WebSocket streams — content isn’t fixed, it’s alive. 
+- Memory, history, and context travel with the user. 
 
-## 📊 Not Just Finance Tools — Actual Assistance
-- Don’t show them a chart, help them *understand* the story.
-- Tie in data from transactions, docs, email, CRM — all in one thread.
-- Imagine workflows we haven’t even invented yet.
+## 📊 Not Just Finance Tools
+- Don’t show them a chart, help them *understand* the story. 
+- Tie in data from transactions, docs, email, CRM — all in one thread. 
+- Imagine workflows we haven’t even invented yet. 
 
 ## 🤝 More Human, Less Pressure
-- LLMs create a safe space for “dumb questions.”
-- No sales agenda, no performance anxiety — just clarity.
+- LLMs create a safe space for “dumb questions.” 
+- No sales agenda, no performance anxiety — just clarity. 
 
 ## 🌍 People Are Already Doing This
-- Millions use ChatGPT, Claude, and Perplexity to plan, write, and organize.
-- It’s not futuristic — it’s happening now.
-- We’re not just catching up — we should be leading.
+- Millions use ChatGPT, Claude, and Perplexity to plan, write, and organize. 
+- It’s not futuristic — it’s happening now. 
 
 ## 💸 This Is Not Just About Investment
-- It's not a money problem — it's a speed and mindset problem.
-- Move fast. Be lean. Skip the decks no one reads.
-- Think like a startup. Build like a startup.
+- It’s not a money problem — it’s a speed and mindset problem. 
+- Move fast. Be lean. Skip the decks no one reads. 
+- Think like a startup. Build like a startup. 
 
 ## 🔐 Are You Ready for This?
-- Would you trust an AI to optimize your finances and daily life?
-- Would you trust your bank with the same data?
+
+Would you trust an AI like ChatGPT or Claude to optimize your finances and daily life?
+
+Yes / No
+
+## 🔐 Are You Ready for This?
+
+Would you trust your bank with your email and personal data?
+
+Yes / No
 
 ## 🌐 A New Interface Layer Is Emerging
-- The interface is no longer a screen — it’s an agent.
-- AI will talk to AI, handle your calendar, email, budgeting, and more.
-- The future isn't a product. It's an ecosystem of intelligent collaborators.
+- The interface is no longer just a screen — it’s an agent. 
+- AI will talk to AI, handle your calendar, email, budgeting, and more. 
+- The future isn’t a product. It’s an ecosystem of intelligent collaborators. 

--- a/slides.md
+++ b/slides.md
@@ -1,0 +1,44 @@
+# The Future Is Not a Smarter Spreadsheet
+
+## ⚡️ We Are Moving Fast
+- We’re entering a new era of AI-native products.
+- This isn’t "better dashboards" — it’s a different paradigm.
+- Think: real-time, multimodal, personalized, conversational interfaces.
+
+## 🧠 LLMs Enable a New Kind of Interaction
+- Beyond static tools — users can *ask* instead of *search*.
+- Answers are contextual, personal, and instant.
+- People can explore without needing to know the right question or jargon.
+
+## 🧩 It’s a Stream, Not a Page
+- Continuous conversation across voice, text, images.
+- From PDFs to WebSocket streams — content isn’t fixed, it’s alive.
+- Memory, history, and context travel with the user.
+
+## 📊 Not Just Finance Tools — Actual Assistance
+- Don’t show them a chart, help them *understand* the story.
+- Tie in data from transactions, docs, email, CRM — all in one thread.
+- Imagine workflows we haven’t even invented yet.
+
+## 🤝 More Human, Less Pressure
+- LLMs create a safe space for “dumb questions.”
+- No sales agenda, no performance anxiety — just clarity.
+
+## 🌍 People Are Already Doing This
+- Millions use ChatGPT, Claude, and Perplexity to plan, write, and organize.
+- It’s not futuristic — it’s happening now.
+- We’re not just catching up — we should be leading.
+
+## 💸 This Is Not Just About Investment
+- It's not a money problem — it's a speed and mindset problem.
+- Move fast. Be lean. Skip the decks no one reads.
+- Think like a startup. Build like a startup.
+
+## 🔐 Are You Ready for This?
+- Would you trust an AI to optimize your finances and daily life?
+- Would you trust your bank with the same data?
+
+## 🌐 A New Interface Layer Is Emerging
+- The interface is no longer a screen — it’s an agent.
+- AI will talk to AI, handle your calendar, email, budgeting, and more.
+- The future isn't a product. It's an ecosystem of intelligent collaborators.


### PR DESCRIPTION
## Summary
- add Reveal.js HTML scaffolding that loads slides from markdown
- include source markdown content and instructions to run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e724559c832b9a7c4447bbab02f8